### PR TITLE
Fixing error with NAs when `cl` is specified

### DIFF
--- a/R/interflex.R
+++ b/R/interflex.R
@@ -614,9 +614,9 @@ inter.binning<-function(data,
     
     ## check missing values
     if (na.rm == TRUE) {
-        data <- na.omit(data[,c(Y, D, X, Z, FE)])
+        data <- na.omit(data[,c(Y, D, X, Z, FE, cl)])
     } else {
-        if (sum(is.na(data[,c(Y, D, X, Z, FE)]))>0) {
+        if (sum(is.na(data[,c(Y, D, X, Z, FE, cl)]))>0) {
             stop("Missing values. Try option na.rm = TRUE\n")
         }
     }
@@ -1445,9 +1445,9 @@ inter.kernel <- function(data,
     
     ## check missing values
     if (na.rm == TRUE) {
-        data <- na.omit(data[,c(Y, D, X, Z, FE)])
+        data <- na.omit(data[,c(Y, D, X, Z, FE, cl)])
     } else {
-        if (sum(is.na(data[,c(Y, D, X, Z, FE)]))>0) {
+        if (sum(is.na(data[,c(Y, D, X, Z, FE, cl)]))>0) {
             stop("Missing values. Try option na.rm = TRUE\n")
         }
     }


### PR DESCRIPTION
First, thanks for putting this package together! It's been a really great resource. 

I came across the following bug when trying to use `inter.kernel()`'s block-bootstrapping functionality. If there were any NAs in the `Y` variable, and `na.rm = TRUE` is specified, then I'd get an error saying that the `cl` column was not found in the data. You can replicate the error with the following code: 

```
library(interflex)

data(interflex)
s4$Y[1] <- NA

inter.kernel(Y = "Y", D = "D", X = "X", Z = "Z1",
             data = s4, na.rm = TRUE, cl = "group")

Parallel computing with 4 cores...
Cross-validating bandwidth ... Error in `[.data.frame`(data, , cl) : undefined columns selected
```

It seems to be a pretty simple change to address the error, which is to just add `cl` to the `na.omit()` check in both `inter.kernel()` and `inter.binning()`.  Thanks again, and let me know if I can provide any more information.